### PR TITLE
Add enforcement for canonical length prefixes

### DIFF
--- a/src/errors/base-error.js
+++ b/src/errors/base-error.js
@@ -36,7 +36,9 @@ class BaseError extends Error {
     })
 
     // Set this.stack
-    Error.captureStackTrace(this, this.constructor)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
   }
 }
 

--- a/src/lib/reader.js
+++ b/src/lib/reader.js
@@ -79,6 +79,7 @@ class Reader {
    * @return {Number} Contents of the next byte.
    */
   peekUInt (length) {
+    if (length === 0) return 0
     if (length > Reader.MAX_INT_BYTES) {
       throw new Error('Tried to read too large integer (requested: ' +
         length + ', max: ' + Reader.MAX_INT_BYTES + ')')
@@ -206,7 +207,17 @@ class Reader {
     const length = this.readUInt8()
 
     if (length & Reader.HIGH_BIT) {
-      return this.readUInt(length & Reader.LOWER_SEVEN_BITS)
+      const lengthPrefixLength = length & Reader.LOWER_SEVEN_BITS
+      const actualLength = this.readUInt(lengthPrefixLength)
+
+      // Reject lengths that could have been encoded with a shorter prefix
+      const minLength = Math.max(128, 1 << ((lengthPrefixLength - 1) * 8))
+      if (actualLength < minLength) {
+        throw new ParseError('Length prefix encoding is not canonical: ' +
+          actualLength + ' encoded in ' + lengthPrefixLength + ' bytes')
+      }
+
+      return actualLength
     }
 
     return length

--- a/src/lib/reader.js
+++ b/src/lib/reader.js
@@ -80,6 +80,10 @@ class Reader {
    */
   peekUInt (length) {
     if (length === 0) return 0
+    if (length < 0) {
+      throw new Error('Tried to read integer with negative length (provided: ' +
+        length + ')')
+    }
     if (length > Reader.MAX_INT_BYTES) {
       throw new Error('Tried to read too large integer (requested: ' +
         length + ', max: ' + Reader.MAX_INT_BYTES + ')')

--- a/test/readerSpec.js
+++ b/test/readerSpec.js
@@ -225,6 +225,14 @@ describe('Reader', function () {
         reader.peekUInt(7)
       }, 'Tried to read too large integer (requested: 7, max: 6)')
     })
+
+    it('when trying to read a negative length integer, should throw', function () {
+      const reader = Reader.from(new Buffer('01020304050607', 'hex'))
+
+      assert.throws(() => {
+        reader.peekUInt(-1)
+      }, 'Tried to read integer with negative length (provided: -1)')
+    })
   })
 
   describe('skipUInt', function () {

--- a/test/readerSpec.js
+++ b/test/readerSpec.js
@@ -608,6 +608,38 @@ describe('Reader', function () {
         reader.readLengthPrefix()
       }, 'Tried to read too large integer (requested: 7, max: 6)')
     })
+
+    it('should throw when length prefix is 0x80 (non-canonical)', function () {
+      const reader = Reader.from(new Buffer('80', 'hex'))
+
+      assert.throws(() => {
+        reader.readLengthPrefix()
+      }, 'Length prefix encoding is not canonical: 0 encoded in 0 bytes')
+    })
+
+    it('should throw when length prefix is 0x8100 (non-canonical)', function () {
+      const reader = Reader.from(new Buffer('8100', 'hex'))
+
+      assert.throws(() => {
+        reader.readLengthPrefix()
+      }, 'Length prefix encoding is not canonical: 0 encoded in 1 bytes')
+    })
+
+    it('should throw when length prefix is 0x8101 (non-canonical)', function () {
+      const reader = Reader.from(new Buffer('810100', 'hex'))
+
+      assert.throws(() => {
+        reader.readLengthPrefix()
+      }, 'Length prefix encoding is not canonical: 1 encoded in 1 bytes')
+    })
+
+    it('should throw when length prefix is 0x820001 (non-canonical)', function () {
+      const reader = Reader.from(new Buffer('82000100', 'hex'))
+
+      assert.throws(() => {
+        reader.readLengthPrefix()
+      }, 'Length prefix encoding is not canonical: 1 encoded in 2 bytes')
+    })
   })
 
   describe('readVarOctetString', function () {


### PR DESCRIPTION
Eventually canonicality should be an optional check, but due to time pressure I'd argue to use this simpler behavior for now, which is: always enforce canonicality.